### PR TITLE
Set up How to Use modal, closes #14

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -563,6 +563,10 @@ video {
   visibility: visible;
 }
 
+.fixed {
+  position: fixed;
+}
+
 .absolute {
   position: absolute;
 }
@@ -571,9 +575,21 @@ video {
   position: relative;
 }
 
+.inset-0 {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
 .inset-y-0 {
   top: 0px;
   bottom: 0px;
+}
+
+.inset-x-0 {
+  left: 0px;
+  right: 0px;
 }
 
 .right-0 {
@@ -586,6 +602,10 @@ video {
 
 .left-0 {
   left: 0px;
+}
+
+.bottom-0 {
+  bottom: 0px;
 }
 
 .z-10 {
@@ -601,6 +621,11 @@ video {
   margin-right: auto;
 }
 
+.mx-1 {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
 .mb-2 {
   margin-bottom: 0.5rem;
 }
@@ -609,12 +634,28 @@ video {
   margin-bottom: 5rem;
 }
 
-.mr-10 {
-  margin-right: 2.5rem;
+.mt-3 {
+  margin-top: 0.75rem;
 }
 
-.mr-20 {
-  margin-right: 5rem;
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.ml-2 {
+  margin-left: 0.5rem;
+}
+
+.ml-4 {
+  margin-left: 1rem;
+}
+
+.ml-auto {
+  margin-left: auto;
+}
+
+.mr-5 {
+  margin-right: 1.25rem;
 }
 
 .block {
@@ -653,6 +694,14 @@ video {
   height: 100%;
 }
 
+.h-12 {
+  height: 3rem;
+}
+
+.h-5 {
+  height: 1.25rem;
+}
+
 .min-h-full {
   min-height: 100%;
 }
@@ -663,6 +712,34 @@ video {
 
 .w-full {
   width: 100%;
+}
+
+.w-12 {
+  width: 3rem;
+}
+
+.w-5 {
+  width: 1.25rem;
+}
+
+.w-1 {
+  width: 0.25rem;
+}
+
+.w-2 {
+  width: 0.5rem;
+}
+
+.w-4 {
+  width: 1rem;
+}
+
+.w-8 {
+  width: 2rem;
+}
+
+.w-10 {
+  width: 2.5rem;
 }
 
 .min-w-full {
@@ -677,12 +754,8 @@ video {
   max-width: 24rem;
 }
 
-.max-w-lg {
-  max-width: 32rem;
-}
-
-.max-w-full {
-  max-width: 100%;
+.max-w-xs {
+  max-width: 20rem;
 }
 
 .flex-1 {
@@ -693,12 +766,50 @@ video {
   flex-shrink: 0;
 }
 
+.flex-shrink {
+  flex-shrink: 1;
+}
+
+.translate-y-4 {
+  --tw-translate-y: 1rem;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.translate-y-0 {
+  --tw-translate-y: 0px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.transform {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.list-disc {
+  list-style-type: disc;
+}
+
+.flex-row {
+  flex-direction: row;
+}
+
 .flex-col {
   flex-direction: column;
 }
 
+.items-start {
+  align-items: flex-start;
+}
+
+.items-end {
+  align-items: flex-end;
+}
+
 .items-center {
   align-items: center;
+}
+
+.justify-end {
+  justify-content: flex-end;
 }
 
 .justify-center {
@@ -725,6 +836,10 @@ video {
   overflow: hidden;
 }
 
+.overflow-y-auto {
+  overflow-y: auto;
+}
+
 .rounded-md {
   border-radius: 0.375rem;
 }
@@ -733,13 +848,53 @@ video {
   border-radius: 0.25rem;
 }
 
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+
+.rounded-full {
+  border-radius: 9999px;
+}
+
 .border {
   border-width: 1px;
+}
+
+.border-t {
+  border-top-width: 1px;
+}
+
+.border-b {
+  border-bottom-width: 1px;
 }
 
 .border-white {
   --tw-border-opacity: 1;
   border-color: rgb(255 255 255 / var(--tw-border-opacity));
+}
+
+.border-transparent {
+  border-color: transparent;
+}
+
+.border-gray-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+}
+
+.border-blue-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(59 130 246 / var(--tw-border-opacity));
+}
+
+.border-sky-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(14 165 233 / var(--tw-border-opacity));
+}
+
+.border-red-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(239 68 68 / var(--tw-border-opacity));
 }
 
 .bg-emerald-800 {
@@ -757,6 +912,53 @@ video {
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
 
+.bg-gray-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(107 114 128 / var(--tw-bg-opacity));
+}
+
+.bg-red-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 226 226 / var(--tw-bg-opacity));
+}
+
+.bg-gray-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity));
+}
+
+.bg-red-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(220 38 38 / var(--tw-bg-opacity));
+}
+
+.bg-gray-800 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+}
+
+.bg-transparent {
+  background-color: transparent;
+}
+
+.bg-blue-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(219 234 254 / var(--tw-bg-opacity));
+}
+
+.bg-sky-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(224 242 254 / var(--tw-bg-opacity));
+}
+
+.bg-opacity-75 {
+  --tw-bg-opacity: 0.75;
+}
+
+.bg-opacity-50 {
+  --tw-bg-opacity: 0.5;
+}
+
 .object-cover {
   -o-object-fit: cover;
      object-fit: cover;
@@ -764,6 +966,18 @@ video {
 
 .p-2 {
   padding: 0.5rem;
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.p-1\.5 {
+  padding: 0.375rem;
+}
+
+.p-1 {
+  padding: 0.25rem;
 }
 
 .px-2 {
@@ -806,6 +1020,26 @@ video {
   padding-bottom: 0.25rem;
 }
 
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.px-1\.5 {
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+}
+
+.py-1\.5 {
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+}
+
 .pr-2 {
   padding-right: 0.5rem;
 }
@@ -818,8 +1052,48 @@ video {
   padding-bottom: 0.75rem;
 }
 
+.pt-5 {
+  padding-top: 1.25rem;
+}
+
+.pb-4 {
+  padding-bottom: 1rem;
+}
+
+.pr-1 {
+  padding-right: 0.25rem;
+}
+
+.pl-1 {
+  padding-left: 0.25rem;
+}
+
+.pl-5 {
+  padding-left: 1.25rem;
+}
+
+.pr-5 {
+  padding-right: 1.25rem;
+}
+
+.pr-10 {
+  padding-right: 2.5rem;
+}
+
+.pl-10 {
+  padding-left: 2.5rem;
+}
+
+.text-left {
+  text-align: left;
+}
+
 .text-center {
   text-align: center;
+}
+
+.text-right {
+  text-align: right;
 }
 
 .text-2xl {
@@ -842,8 +1116,21 @@ video {
   line-height: 1.75rem;
 }
 
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
 .font-medium {
   font-weight: 500;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.leading-6 {
+  line-height: 1.5rem;
 }
 
 .text-white {
@@ -861,8 +1148,111 @@ video {
   color: rgb(6 95 70 / var(--tw-text-opacity));
 }
 
+.text-red-600 {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity));
+}
+
+.text-gray-900 {
+  --tw-text-opacity: 1;
+  color: rgb(17 24 39 / var(--tw-text-opacity));
+}
+
+.text-gray-500 {
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity));
+}
+
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity));
+}
+
+.text-gray-400 {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity));
+}
+
+.text-emerald-200 {
+  --tw-text-opacity: 1;
+  color: rgb(167 243 208 / var(--tw-text-opacity));
+}
+
+.text-red-800 {
+  --tw-text-opacity: 1;
+  color: rgb(153 27 27 / var(--tw-text-opacity));
+}
+
+.text-sky-600 {
+  --tw-text-opacity: 1;
+  color: rgb(2 132 199 / var(--tw-text-opacity));
+}
+
+.text-blue-700 {
+  --tw-text-opacity: 1;
+  color: rgb(29 78 216 / var(--tw-text-opacity));
+}
+
+.text-sky-700 {
+  --tw-text-opacity: 1;
+  color: rgb(3 105 161 / var(--tw-text-opacity));
+}
+
+.text-red-700 {
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity));
+}
+
 .underline {
   text-decoration-line: underline;
+}
+
+.placeholder-emerald-200::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(167 243 208 / var(--tw-placeholder-opacity));
+}
+
+.placeholder-emerald-200::placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(167 243 208 / var(--tw-placeholder-opacity));
+}
+
+.placeholder-emerald-400::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(52 211 153 / var(--tw-placeholder-opacity));
+}
+
+.placeholder-emerald-400::placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(52 211 153 / var(--tw-placeholder-opacity));
+}
+
+.placeholder-emerald-600::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(5 150 105 / var(--tw-placeholder-opacity));
+}
+
+.placeholder-emerald-600::placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(5 150 105 / var(--tw-placeholder-opacity));
+}
+
+.placeholder-emerald-500::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(16 185 129 / var(--tw-placeholder-opacity));
+}
+
+.placeholder-emerald-500::placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(16 185 129 / var(--tw-placeholder-opacity));
+}
+
+.opacity-0 {
+  opacity: 0;
+}
+
+.opacity-100 {
+  opacity: 1;
 }
 
 .shadow-lg {
@@ -871,14 +1261,69 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-sm {
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .drop-shadow-custom {
   --tw-drop-shadow: drop-shadow(0 0 5px rgba(0, 0, 0, 1));
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
+.transition-opacity {
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-all {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.duration-300 {
+  transition-duration: 300ms;
+}
+
+.duration-200 {
+  transition-duration: 200ms;
+}
+
+.ease-out {
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}
+
+.ease-in {
+  transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+}
+
 .hover\:bg-emerald-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(4 120 87 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-red-700:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(185 28 28 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-gray-50:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-gray-200:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
 }
 
 .hover\:text-sky-200:hover {
@@ -889,6 +1334,21 @@ video {
 .hover\:text-white:hover {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.hover\:text-gray-900:hover {
+  --tw-text-opacity: 1;
+  color: rgb(17 24 39 / var(--tw-text-opacity));
+}
+
+.hover\:placeholder-white:hover::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-placeholder-opacity));
+}
+
+.hover\:placeholder-white:hover::placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-placeholder-opacity));
 }
 
 .focus\:outline-none:focus {
@@ -911,9 +1371,50 @@ video {
   --tw-ring-color: rgb(255 255 255 / var(--tw-ring-opacity));
 }
 
+.focus\:ring-red-500:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(239 68 68 / var(--tw-ring-opacity));
+}
+
+.focus\:ring-indigo-500:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(99 102 241 / var(--tw-ring-opacity));
+}
+
+.focus\:ring-offset-2:focus {
+  --tw-ring-offset-width: 2px;
+}
+
 .active\:bg-emerald-900:active {
   --tw-bg-opacity: 1;
   background-color: rgb(6 78 59 / var(--tw-bg-opacity));
+}
+
+.active\:text-white:active {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.active\:placeholder-white:active::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-placeholder-opacity));
+}
+
+.active\:placeholder-white:active::placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-placeholder-opacity));
+}
+
+@media (prefers-color-scheme: dark) {
+  .dark\:hover\:bg-gray-600:hover {
+    --tw-bg-opacity: 1;
+    background-color: rgb(75 85 99 / var(--tw-bg-opacity));
+  }
+
+  .dark\:hover\:text-white:hover {
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity));
+  }
 }
 
 @media (min-width: 640px) {
@@ -928,16 +1429,91 @@ video {
     left: auto;
   }
 
+  .sm\:my-8 {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .sm\:mx-0 {
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
   .sm\:ml-6 {
     margin-left: 1.5rem;
+  }
+
+  .sm\:mt-0 {
+    margin-top: 0px;
+  }
+
+  .sm\:ml-4 {
+    margin-left: 1rem;
+  }
+
+  .sm\:ml-3 {
+    margin-left: 0.75rem;
   }
 
   .sm\:block {
     display: block;
   }
 
+  .sm\:flex {
+    display: flex;
+  }
+
   .sm\:hidden {
     display: none;
+  }
+
+  .sm\:h-10 {
+    height: 2.5rem;
+  }
+
+  .sm\:w-full {
+    width: 100%;
+  }
+
+  .sm\:w-10 {
+    width: 2.5rem;
+  }
+
+  .sm\:w-auto {
+    width: auto;
+  }
+
+  .sm\:max-w-lg {
+    max-width: 32rem;
+  }
+
+  .sm\:translate-y-0 {
+    --tw-translate-y: 0px;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+
+  .sm\:scale-95 {
+    --tw-scale-x: .95;
+    --tw-scale-y: .95;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+
+  .sm\:scale-100 {
+    --tw-scale-x: 1;
+    --tw-scale-y: 1;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+
+  .sm\:flex-row-reverse {
+    flex-direction: row-reverse;
+  }
+
+  .sm\:items-start {
+    align-items: flex-start;
+  }
+
+  .sm\:items-center {
+    align-items: center;
   }
 
   .sm\:items-stretch {
@@ -948,6 +1524,14 @@ video {
     justify-content: flex-start;
   }
 
+  .sm\:p-0 {
+    padding: 0px;
+  }
+
+  .sm\:p-6 {
+    padding: 1.5rem;
+  }
+
   .sm\:px-6 {
     padding-left: 1.5rem;
     padding-right: 1.5rem;
@@ -956,11 +1540,64 @@ video {
   .sm\:pr-0 {
     padding-right: 0px;
   }
+
+  .sm\:pb-4 {
+    padding-bottom: 1rem;
+  }
+
+  .sm\:text-left {
+    text-align: left;
+  }
+
+  .sm\:text-sm {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:mb-20 {
+    margin-bottom: 5rem;
+  }
+
+  .md\:mb-10 {
+    margin-bottom: 2.5rem;
+  }
+
+  .md\:w-10 {
+    width: 2.5rem;
+  }
+
+  .md\:w-5 {
+    width: 1.25rem;
+  }
+
+  .md\:w-9 {
+    width: 2.25rem;
+  }
+
+  .md\:w-8 {
+    width: 2rem;
+  }
+
+  .md\:text-center {
+    text-align: center;
+  }
 }
 
 @media (min-width: 1024px) {
+  .lg\:mb-10 {
+    margin-bottom: 2.5rem;
+  }
+
   .lg\:px-8 {
     padding-left: 2rem;
     padding-right: 2rem;
+  }
+}
+
+@media (orientation: landscape) {
+  .landscape\:hidden {
+    display: none;
   }
 }

--- a/index.html
+++ b/index.html
@@ -12,12 +12,17 @@
 
       <!-- USEFUL IDS -->
       <!-- mobile-menu: the hamburger menu for the mobile version of the navbar -->
-      <!-- how-to-use: the instructions card (visible when first loaded) -->
+      <!-- how-to-use: the instructions modal (visible when first loaded) -->
+      <!-- how-to-use-btn: the button that opens the instructions -->
+      <!-- how-to-use-btn-mobile: the button that opens the instructions when the mobile menu is active -->
+      <!-- how-to-use-x: the button that closes the instructions -->
       <!-- main-image: the container for the image (or background video when first loaded) -->
       <!-- control-bar: the section housing the timer and generate/new image buttons -->
-      <!-- set-timer: the set timer button -->
-      <!-- time: the time set/counting down (default display is 00:00) -->
       <!-- gen-image: the generate image button (should switch to say "new image" when in use) -->
+      <!-- set-timer: the set timer button -->
+      <!-- timer-area: where the time should be displayed. initially contains the minute and second input fields  -->
+      <!-- time-minutes: the minutes input field -->
+      <!-- time-seconds: the seconds input field -->
       <!-- photo-credit: where photo credit info should be pulled if possible (has our copyright when first loaded) -->
 
       <main class="flex flex-col h-screen">
@@ -30,12 +35,14 @@
                 <!-- logo text -->
                 <div class="flex flex-1 items-center justify-center sm:items-stretch sm:justify-start">
                     <div class="flex flex-shrink-0 items-center">
-                        <a href="#" class="text-white hover:text-sky-200 px-1 text-2xl font-medium" aria-current="page">Arti<span class="text-sky-200 hover:text-white">Scapes</span></a>
+                        <a href="." class="text-white hover:text-sky-200 px-1 text-2xl font-medium" aria-current="page">Arti<span class="text-sky-200 hover:text-white">Scapes</span></a>
                     </div>
                 </div>
 
                 <!-- mobile menu button-->
                 <div class="absolute inset-y-0 right-0 flex items-center sm:hidden" onclick="menuToggle()">
+                  <!-- NOTE ARIA LABELS: the aria-controls label indicates that this button controls the element with id "mobile-menu" -->
+                  <!-- the aria-expanded label stats whether the menu is open or closed and needs to be included in the JS toggle -->
                   <button type="button" class="inline-flex items-center justify-center rounded-md p-2 text-white hover:bg-emerald-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white" aria-controls="mobile-menu" aria-expanded="false">
                     <span class="sr-only">Open main menu</span>
                     <!--
@@ -61,8 +68,14 @@
                 <div class="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
                     <div class="hidden sm:ml-6 sm:block">
                         <div class="flex space-x-4">
-                          <a href="#" class="bg-emerald-900 text-white px-3 py-2 rounded-md text-sm font-medium" aria-current="page">How to Use</a>
+                          <!-- NOTE ARIA LABELS: aria-current on How to Use needs to be switched to work with the modal rather than pages -->
+                          <!-- I think the correct label will be aria-modal and it will function like aria-expanded, needing to be set true/false by JS -->
+                          <!-- Where to Paint will also need labels updated depending on how we have it appear on the page -->
+
+                          <a id="how-to-use-btn" href="#" class="text-white bg-emerald-900 px-3 py-2 rounded-md text-sm font-medium" aria-current="page">How to Use</a>
+
                           <a href="#" class="border border-white text-white hover:bg-emerald-700 px-3 active:bg-emerald-900 py-2 rounded-md text-sm font-medium">Where to Paint <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 inline"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg></a>
+                        
                         </div>
                       </div>
                 </div>
@@ -70,10 +83,14 @@
             </div>
           
             <!-- Mobile menu, show/hide based on menu state. -->
-            <div class="sm:hidden hidden" id="mobile-menu">
+            <div class="sm:hidden hidden text-right" id="mobile-menu">
               <div class="space-y-1 px-2 pt-2 pb-3">
-                <a href="#" class="bg-emerald-900 text-white block px-3 py-2 rounded-md text-base font-medium" aria-current="page">How to Use</a>
-                <a href="#" class="text-white hover:bg-emerald-700 block px-3 py-2 rounded-md text-base font-medium">Where to Paint <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 inline"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg></a>
+                <!-- NOTE ARIA LABELS: see comments about the non-mobile version -->
+
+                <a id="how-to-use-btn-mobile" href="#" class="bg-emerald-900 text-white block px-3 py-2 rounded-md text-base font-medium" aria-current="page">How to Use</a>
+
+                <a href="#" class="text-white hover:bg-emerald-700 active:bg-emerald-900 block px-3 py-2 rounded-md text-base font-medium">Where to Paint <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 inline"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg></a>
+              
               </div>
             </div>
           </nav>
@@ -81,28 +98,14 @@
           <!-- MAIN CONTENT -->
           <section class="relative h-screen flex flex-col items-center justify-between text-white py-0 px-3">
             <!-- video -->
-            <div class="absolute top-0 left-0 w-full h-full overflow-hidden" id="main-image">
-             
+            <div class="absolute top-0 left-0 w-full h-full overflow-hidden" id="main-image" aria-label="current reference image">
               <video class="min-w-full min-h-full absolute object-cover" src="vid/bg-video.webm" type="video/mp4" autoplay muted defaultMuted loop></video>
               <video class="min-w-full min-h-full absolute object-cover" src="vid/bg-video.mp4" type="video/mp4" autoplay muted defaultMuted loop></video>
             </div>
-                
-            <!-- instructions card -->
-            <div id="how-to-use" class="z-10 m-auto">
-              <div class="max-w-sm rounded overflow-hidden shadow-lg bg-white">
-                  <div class="bg-emerald-800 text-xl mb-2 px-6 py-2">
-                    <h1 class="text-white text-center">How to Use</h1>
-                  </div>
-                  <p class="text-emerald-800 text-base px-6 py-4">
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatibus quia, nulla! Maiores et perferendis eaque, exercitationem praesentium nihil.
-                  </p>
-              </div>
-
                   
-            </div>
             <!-- CONTROLS AND FOOTER -->
-            <section class="flex flex-col justify-between z-10 mx-auto text-center w-full max-w-sm">
-              <div id="control-bar" class="bg-emerald-800 rounded-md mb-20 p-2 flex justify-between">
+            <section class="absolute z-10 mx-auto text-center w-full max-w-sm inset-x-0 bottom-0">
+              <div id="control-bar" class="bg-emerald-800 rounded-md mb-2 md:mb-10 p-2 flex justify-between">
                 <!-- left buttons -->
                 <div>
                   <button id="set-timer" class="rounded-md border border-white px-2 py-1 hover:bg-emerald-700 active:bg-emerald-900">Set Timer</button>
@@ -113,10 +116,68 @@
               </div>
               <footer>
                 <p id="photo-credit" class="drop-shadow-custom">Copyright © <a href="https://github.com/BJThompson12/Sea-Wolves" class="underline">Sea Wolves</a> 2023</p>
-              
               </footer>
             </section>
           </section>
+
+          <!-- HOW TO USE MODAL -->
+          <div id="how-to-use" class="relative z-10" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+            <!--
+              Background backdrop, show/hide based on modal state.
+          
+              Entering: "ease-out duration-300"
+                From: "opacity-0"
+                To: "opacity-100"
+              Leaving: "ease-in duration-200"
+                From: "opacity-100"
+                To: "opacity-0"
+            -->
+            <div class="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity"></div>
+          
+            <div class="fixed inset-0 z-10 overflow-y-auto">
+              <div class="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
+                <!--
+                  Modal panel, show/hide based on modal state.
+          
+                  Entering: "ease-out duration-300"
+                    From: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                    To: "opacity-100 translate-y-0 sm:scale-100"
+                  Leaving: "ease-in duration-200"
+                    From: "opacity-100 translate-y-0 sm:scale-100"
+                    To: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                -->
+                <div class="relative transform overflow-hidden rounded-lg text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+                  <div class="bg-white rounded-lg">
+                        <!-- modal header -->
+                        <div class="relative flex items-center justify-between bg-emerald-800 text-xl px-6 py-2">
+                          <div class="flex flex-1 items-center justify-center">
+                            <!-- modal title -->
+                            <div class="flex flex-shrink-0 items-center">
+                              <h2 class="text-white text-center">How to Use</h2>
+                            </div>
+                            <!-- modal close button -->
+                            <div class="absolute inset-y-0 right-0 flex items-center mx-1">
+                              <button id="how-to-use-x" type="button" class="text-white hover:bg-emerald-700 active:bg-emerald-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center" data-modal-hide="defaultModal">
+                                <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+                                <span class="sr-only">Close modal</span>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="landscape:hidden text-center bg-red-100 border-t border-b border-red-500 text-red-700 px-4 py-3" role="alert">
+                          <p class="font-bold">ArtiScapes is optimized for landscape orientation.</p>
+                          <p class="text-sm">Your device is currently in portrait orientation.</p>
+                        </div>
+                        <ul class="text-emerald-800 text-base ml-4 px-6 py-4 list-disc">
+                          <li>To generate a new random landscape picture, click or tap the <strong>Generate Image</strong> button.</li>
+                          <li>To use the timer option, type the minutes and seconds into the timer display and click or tap the <strong>Set Timer</strong> button. When the timer reaches 0, the image will automatically switch.</li>
+                          <li>To hide most of the user interface (UI) and better see the full image, click the <strong>Hide UI</strong> button in the lower left corner. Click again to bring the UI back.</li>
+                        </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 
       </main>
 

--- a/js/script.js
+++ b/js/script.js
@@ -32,6 +32,7 @@ function displayImage(imageURL, userSite, name){
    `
 }
 
+// mobile menu toggle (will rework this so it doesn't use the HTML attribute for onclick)
 function menuToggle() {
   var x = document.getElementById("mobile-menu");
   if (x.classList.contains("hidden")) {
@@ -40,3 +41,29 @@ function menuToggle() {
     x.classList.add("hidden");
   }
 }
+
+// "how to use" open and close
+const howToUseEl = document.getElementById('how-to-use');
+const howToUseBtn = document.getElementById('how-to-use-btn');
+const howToUseBtnMobile = document.getElementById('how-to-use-btn-mobile');
+const howToUseX = document.getElementById('how-to-use-x');
+
+function howToToggle() {
+  if (howToUseEl.classList.contains("hidden")) {
+    howToUseEl.classList.remove("hidden");
+    howToUseBtn.classList.add("bg-emerald-900");
+    howToUseBtnMobile.classList.add("bg-emerald-900");
+    howToUseBtn.classList.remove("hover:bg-emerald-700", "active:bg-emerald-900", "border", "border-white");
+    howToUseBtnMobile.classList.remove("hover:bg-emerald-700", "active:bg-emerald-900");
+  } else {
+    howToUseEl.classList.add("hidden");
+    howToUseBtn.classList.remove("bg-emerald-900");
+    howToUseBtnMobile.classList.remove("bg-emerald-900");
+    howToUseBtn.classList.add("hover:bg-emerald-700", "active:bg-emerald-900", "border", "border-white");
+    howToUseBtnMobile.classList.add("hover:bg-emerald-700", "active:bg-emerald-900");
+  }
+}
+
+howToUseBtn.addEventListener('click', howToToggle);
+howToUseBtnMobile.addEventListener('click', howToToggle);
+howToUseX.addEventListener('click', howToToggle);


### PR DESCRIPTION
- Made How to Use into a modal that is open by default on page load. (Maybe we could use localStorage to have this only show the first time, and store if a user has already clicked the close button?)
- Adjusted position of the controls bar to stay on the bottom and be closer to the copyright line on smaller screens
- Added a warning message to the modal that displays when the user's device is in portrait orientation instead of landscape