### PR TITLE
Add API key file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 .DS_store
 
 # VS Code settings
-.vscode
+.vscode/
 
 # node modules (use npm ci in terminal to install the files based on package-lock.json)
 node_modules/
+
+# ignore API key file
+js/key.js

--- a/index.html
+++ b/index.html
@@ -193,6 +193,7 @@
       </main>
 
       <script src="js/script.js"></script>
+      <script src="js/key.js"></script>
       <script src="js/script2.js"></script>
 
     </body>

--- a/js/script2.js
+++ b/js/script2.js
@@ -1,6 +1,6 @@
 //Google map/places near me API
 // Add your google map api key here
-const API_KEY = ''
+const API_KEY = googleKey;
 let map;
 let service;
 let infowindow;


### PR DESCRIPTION
- Created a key.js file (not pushed)
- Linked to key.js in the HTML file
- Referenced "googleKey" for the value of the API key in script2

To use, create a file key.js inside the js folder (MUST BE IN THE FOLDER js, OTHERWISE IT WILL GET PUSHED) and add this line and save:
`const googleKey = "paste the API key Poonam sent us here";`