### PR TITLE
Add contrast to footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -419,12 +419,8 @@ video {
   display: none;
 }
 
-input[type="number"]::-webkit-inner-spin-button,
-    input[type="number"]::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-  /* this currently isn't working on firefox - investigate */
-  -moz-appearance: none;
+.text-shadow {
+  text-shadow: 2px 2px 5px #000, 2px -2px 5px #000, -2px -2px 5px #000, -2px 2px 5px #000;
 }
 
 *, ::before, ::after {
@@ -670,10 +666,6 @@ input[type="number"]::-webkit-inner-spin-button,
   margin-bottom: 0.5rem;
 }
 
-.mb-20 {
-  margin-bottom: 5rem;
-}
-
 .block {
   display: block;
 }
@@ -738,10 +730,6 @@ input[type="number"]::-webkit-inner-spin-button,
   width: 1.25rem;
 }
 
-.w-32 {
-  width: 8rem;
-}
-
 .w-40 {
   width: 10rem;
 }
@@ -788,10 +776,6 @@ input[type="number"]::-webkit-inner-spin-button,
 
 .justify-between {
   justify-content: space-between;
-}
-
-.gap-1 {
-  gap: 0.25rem;
 }
 
 .gap-2 {
@@ -974,16 +958,6 @@ input[type="number"]::-webkit-inner-spin-button,
   padding-bottom: 1rem;
 }
 
-.py-10 {
-  padding-top: 2.5rem;
-  padding-bottom: 2.5rem;
-}
-
-.px-10 {
-  padding-left: 2.5rem;
-  padding-right: 2.5rem;
-}
-
 .pr-2 {
   padding-right: 0.5rem;
 }
@@ -996,12 +970,12 @@ input[type="number"]::-webkit-inner-spin-button,
   padding-bottom: 0.75rem;
 }
 
-.pb-10 {
-  padding-bottom: 2.5rem;
-}
-
 .pb-2 {
   padding-bottom: 0.5rem;
+}
+
+.pb-1 {
+  padding-bottom: 0.25rem;
 }
 
 .text-left {
@@ -1094,16 +1068,11 @@ input[type="number"]::-webkit-inner-spin-button,
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.drop-shadow-custom {
-  --tw-drop-shadow: drop-shadow(0 0 5px rgba(0, 0, 0, 1));
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
 .filter {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
-/* removes the arrows from number inputs */
+/* adds a custom text-shadow for the footer */
 
 .hover\:bg-emerald-700:hover {
   --tw-bg-opacity: 1;
@@ -1118,6 +1087,11 @@ input[type="number"]::-webkit-inner-spin-button,
 .hover\:text-white:hover {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.hover\:text-emerald-500:hover {
+  --tw-text-opacity: 1;
+  color: rgb(16 185 129 / var(--tw-text-opacity));
 }
 
 .hover\:placeholder-white:hover::-moz-placeholder {
@@ -1200,6 +1174,10 @@ input[type="number"]::-webkit-inner-spin-button,
     display: block;
   }
 
+  .sm\:inline {
+    display: inline;
+  }
+
   .sm\:hidden {
     display: none;
   }
@@ -1235,6 +1213,12 @@ input[type="number"]::-webkit-inner-spin-button,
 
   .sm\:pr-0 {
     padding-right: 0px;
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:inline {
+    display: inline;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
           
             <!-- mobile menu, show/hide based on menu state. -->
             <div class="sm:hidden hidden" id="mobile-menu">
-              <div class="space-y-1 px-2 pt-2 pb-3 text-center">
+              <div class="space-y-1 px-2 pb-2 text-center">
                 <ul>
                   <li id="how-to-use-btn-mobile" aria-expanded="true" class="text-white hover:bg-emerald-700 block px-3 py-2 rounded-md text-base font-medium">
                     How to Use
@@ -170,9 +170,9 @@
                 </div>
               </div>
               <footer>
-                <p id="photo-credit" class="drop-shadow-custom">
-                  Copyright © <a href="https://github.com/BJThompson12/Sea-Wolves" class="underline">Sea Wolves</a> 2023
-                </p>
+                <div class="text-shadow text-sm text-white">
+                  <p class="sm:inline">Copyright © <a href="https://github.com/BJThompson12/Sea-Wolves" class="hover:text-emerald-500 underline">Sea Wolves</a> 2023<span class="hidden sm:inline"> | </span></p><p id="photo-credit" class="sm:inline">Video by <a href="https://www.pexels.com/video/scenery-of-relaxing-farm-field-during-daytime-4471213/" target="_blank" class="hover:text-emerald-500 underline">Mike B</a></p>
+                </div>
               </footer>
             </section>
           </section>

--- a/js/script.js
+++ b/js/script.js
@@ -56,12 +56,12 @@ function getImage() {
     const showRecentPhotoMessage = document.getElementById('recents-container')
       if (recentPhotoArray.length == 0) {
         showRecentPhotoMessage.innerHTML = `
-        <p> You have no recent images to display.</p>
+        <p>You have no recent images to display.</p>
         `
         console.log('empty');
       } else {
         showRecentPhotoMessage.innerHTML = `
-        <p> Your most recently viewed images.</p>
+        <p>Your most recently viewed images:</p>
         `
       }
 
@@ -91,7 +91,7 @@ function getImage() {
     
     mainPageEl.innerHTML = `<img class="min-w-full min-h-full absolute object-cover" src="${image}" alt=""> `;
     
-    footerEl.innerHTML = `Photo By: <a href="${userSite}" target="_blank" class="underline">${name}</a>`;
+    footerEl.innerHTML = `Photo by <a href="${userSite}" target="_blank" class="underline hover:text-emerald-500">${name}</a>`;
   };
   
 // MOBILE MENU TOGGLE

--- a/style.css
+++ b/style.css
@@ -2,13 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-/* removes the arrows from number inputs */
+/* adds a custom text-shadow for the footer */
 @layer base {
-    input[type="number"]::-webkit-inner-spin-button,
-    input[type="number"]::-webkit-outer-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-      /* this currently isn't working on firefox - investigate */
-      -moz-appearance: none;
+    .text-shadow {
+      text-shadow: 2px 2px 5px #000, 2px -2px 5px #000, -2px -2px 5px #000, -2px 2px 5px #000;
     }
   }


### PR DESCRIPTION
- Added a custom CSS class to create a large contrasting shadow behind the footer text.
- Removed an old unused custom class.
- Made the copyright persist between images.
- Made copyright stack above image credit on mobile.
- Non-footer-related tweak: Changed Image History text to end with a colon instead of a period.