### PR TITLE
Fix Hide UI location on mobile and optimize video for autoplay

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -608,6 +608,30 @@ video {
   bottom: 0px;
 }
 
+.top-64 {
+  top: 16rem;
+}
+
+.top-48 {
+  top: 12rem;
+}
+
+.top-24 {
+  top: 6rem;
+}
+
+.top-12 {
+  top: 3rem;
+}
+
+.top-16 {
+  top: 4rem;
+}
+
+.top-20 {
+  top: 5rem;
+}
+
 .z-20 {
   z-index: 20;
 }
@@ -1145,6 +1169,14 @@ video {
     left: auto;
   }
 
+  .sm\:bottom-0 {
+    bottom: 0px;
+  }
+
+  .sm\:top-auto {
+    top: auto;
+  }
+
   .sm\:my-8 {
     margin-top: 2rem;
     margin-bottom: 2rem;
@@ -1197,6 +1229,12 @@ video {
 
   .sm\:pr-0 {
     padding-right: 0px;
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:bottom-0 {
+    bottom: 0px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -148,13 +148,15 @@
 
             <!-- VIDEO/IMAGE -->
             <div class="absolute top-0 left-0 w-full h-full overflow-hidden" id="main-image" aria-label="current reference image">
-              <video class="min-w-full min-h-full absolute object-cover" src="vid/bg-video.webm" type="video/mp4" autoplay muted defaultMuted loop></video>
-              <video class="min-w-full min-h-full absolute object-cover" src="vid/bg-video.mp4" type="video/mp4" autoplay muted defaultMuted loop></video>
+              <video class="min-w-full min-h-full absolute object-cover" autoplay="autoplay" loop="loop" muted defaultMuted playsinline preload="auto">
+                <source src="vid/bg-video.webm" type="video/webm">
+                <source src="vid/bg-video.mp4" type="video/mp4">
+              </video>
             </div>
                   
             <!-- CONTROLS AND FOOTER -->
-            <section class="absolute z-10 mx-auto text-center w-full max-w-sm inset-x-0 bottom-0">
-              <div id="control-bar" class="bg-emerald-800 rounded-md mb-10 p-2 flex justify-between"> <!-- will be hidden by Hide UI -->
+            <section class="absolute z-10 mx-auto text-center w-full inset-x-0 bottom-0">
+              <div id="control-bar" class="bg-emerald-800 max-w-sm rounded-md mx-auto mb-10 p-2 flex justify-between"> <!-- will be hidden by Hide UI -->
                 <!-- left button -->
                 <button id="gen-image" aria-label="next image" aria-controls="main-image" class="rounded-md border border-white px-2 py-1 hover:bg-emerald-700 active:bg-emerald-900">
                   Next Image
@@ -173,7 +175,7 @@
                 </div>
               </div>
               <footer>
-                <div class="text-shadow text-sm text-white">
+                <div class="text-shadow text-sm text-white w-full">
                   <p class="sm:inline">Copyright © <a href="https://github.com/BJThompson12/Sea-Wolves" class="hover:text-emerald-500 underline">Sea Wolves</a> 2023<span class="hidden sm:inline"> | </span></p><p id="photo-credit" class="sm:inline">Video by <a href="https://www.pexels.com/video/scenery-of-relaxing-farm-field-during-daytime-4471213/" target="_blank" class="hover:text-emerald-500 underline">Mike B</a></p>
                 </div>
               </footer>
@@ -252,7 +254,7 @@
           </div>
 
           <!-- HIDE UI -->
-          <div class="absolute bottom-0 left-0 z-10">
+          <div class="fixed bottom-0 left-0 z-10">
             <button id="hide-ui-btn" class="rounded ml-2 mb-2 px-2 py-1 bg-emerald-800 hover:bg-emerald-700 active:bg-emerald-900 text-white text-sm">
               Hide UI
             </button>


### PR DESCRIPTION
- Changed Hide UI to "fixed" instead of "absolute" so it (hopefully) won't move in mobile browsers
- Edited the video code so that it looks the same but should autoplay at least on some mobile browsers
- Increased width on footer so it doesn't turn into two lines when the photographer's name is long